### PR TITLE
Add target-cpu to cargo/config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,6 +3,7 @@ target = "xtensa-none-elf"
 
 [target.xtensa-none-elf]
 rustflags = [
+  "-C", "target-cpu=esp32",
   "-C", "save-temps",
   "-C", "link-arg=-nostdlib",
 


### PR DESCRIPTION
Thanks for your great work!
Since recent xtensa llvm supports both esp32 and esp8266, I had to explicitly set target-cpu.